### PR TITLE
✨ Feat: Add @SubCollectionDoc decorator and fix empty document instantiation

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -52,6 +52,13 @@ export interface SubCollectionMetadata<T extends typeof BaseModel = any> {
   model: () => BaseModelConstructor<T>;
 }
 
+export interface SubCollectionDocMetadata<T extends typeof BaseModel = any> {
+  propertyName: string;
+  docId: string;
+  subcollectionName: string;
+  model: () => BaseModelConstructor<T>;
+}
+
 export interface BaseModelConstructor<T extends typeof BaseModel = any> {
   new (data: Partial<Record<string, any>>, id?: string): T;
   schema?: ZodSchema<any>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,8 @@ export {
   StringField,
   TimestampField,
   EnumField,
-  SubCollection
+  SubCollection,
+  SubCollectionDoc
 } from "./core/decorators";
 
 // --- Types and Interfaces ---
@@ -26,7 +27,8 @@ export type {
   FindOptions,
   RelationMetadata,
   SubModelMetadata,
-  SubCollectionMetadata
+  SubCollectionMetadata,
+  SubCollectionDocMetadata
 } from "./core/types";
 
 // --- Errors ---

--- a/tests/subcollection-doc.test.ts
+++ b/tests/subcollection-doc.test.ts
@@ -1,0 +1,193 @@
+import {
+  BaseModel,
+  Collection,
+  getFirestoreInstance,
+  StringField,
+  SubCollection,
+  SubCollectionDoc,
+  SubCollectionModel,
+  Timestamp,
+  TimestampField,
+} from "../src";
+
+@SubCollectionModel(() => MasterData, "access-logs")
+class AccessLog extends BaseModel {
+  @StringField({ required: true })
+  ip!: string;
+
+  @TimestampField({ autoFill: true })
+  accessedAt?: Timestamp;
+
+  constructor(data: Partial<AccessLog>, idOrParent?: string | BaseModel) {
+    super(data, idOrParent);
+  }
+}
+
+@SubCollectionModel(() => Employee, "advanced-data")
+class MasterData extends BaseModel {
+  @StringField({ required: true })
+  accessLevel!: string;
+
+  @SubCollection(() => AccessLog, "access-logs")
+  accessLogs?: AccessLog[];
+
+  constructor(data: Partial<MasterData>, idOrParent?: string | BaseModel) {
+    super(data, idOrParent);
+  }
+}
+
+@SubCollectionModel(() => Employee, "advanced-data")
+class GeneralData extends BaseModel {
+  @StringField({ required: true })
+  location!: string;
+
+  constructor(data: Partial<GeneralData>, idOrParent?: string | BaseModel) {
+    super(data, idOrParent);
+  }
+}
+
+@Collection("employees")
+class Employee extends BaseModel {
+  @StringField({ required: true })
+  name!: string;
+
+  @SubCollectionDoc(() => GeneralData, "general", {
+    subcollection: "advanced-data",
+  })
+  generalData?: GeneralData;
+
+  @SubCollectionDoc(() => MasterData, "master-data", {
+    subcollection: "advanced-data",
+  })
+  masterData?: MasterData;
+
+  constructor(data: Partial<Employee>, id?: string) {
+    super(data, id);
+  }
+}
+
+beforeEach(async () => {
+  const db = getFirestoreInstance();
+  const employeesSnap = await db.collection("employees").get();
+
+  for (const employeeDoc of employeesSnap.docs) {
+    const advancedDataColRef = employeeDoc.ref.collection("advanced-data");
+    const advancedDataSnap = await advancedDataColRef.get();
+
+    for (const advancedDoc of advancedDataSnap.docs) {
+      if (advancedDoc.id === "master-data") {
+        const accessLogsColRef = advancedDoc.ref.collection("access-logs");
+        const accessLogsSnap = await accessLogsColRef.get();
+        await Promise.all(
+          accessLogsSnap.docs.map((logDoc) => logDoc.ref.delete())
+        );
+      }
+      await advancedDoc.ref.delete();
+    }
+
+    await employeeDoc.ref.delete();
+  }
+});
+
+describe("SubCollectionDoc and Nested SubCollection", () => {
+  it("should populate a single document from a subcollection using findById", async () => {
+    const employee = new Employee({ name: "John" });
+    await employee.save();
+
+    const general = new GeneralData({ location: "New York" }, employee);
+    general.id = "general";
+    await general.save();
+
+    const fetchedEmployee = await Employee.findById(employee.id!, {
+      populate: ["generalData"],
+    });
+
+    expect(fetchedEmployee).toBeInstanceOf(Employee);
+    expect(fetchedEmployee?.generalData).toBeInstanceOf(GeneralData);
+    expect(fetchedEmployee?.generalData?.location).toBe("New York");
+    expect(fetchedEmployee?.generalData?.id).toBe("general");
+    expect(fetchedEmployee?.masterData).toBeUndefined();
+  });
+
+  it("should populate multiple documents from the same subcollection", async () => {
+    const employee = new Employee({ name: "Jane" });
+    await employee.save();
+
+    const general = new GeneralData({ location: "London" }, employee);
+    general.id = "general";
+    await general.save();
+
+    const master = new MasterData({ accessLevel: "admin" }, employee);
+    master.id = "master-data";
+    await master.save();
+
+    const fetchedEmployee = await Employee.findById(employee.id!, {
+      populate: ["generalData", "masterData"],
+    });
+
+    expect(fetchedEmployee?.generalData).toBeInstanceOf(GeneralData);
+    expect(fetchedEmployee?.generalData?.location).toBe("London");
+    expect(fetchedEmployee?.masterData).toBeInstanceOf(MasterData);
+    expect(fetchedEmployee?.masterData?.accessLevel).toBe("admin");
+  });
+
+  it("should return null for a populated property if the document does not exist", async () => {
+    const employee = new Employee({ name: "Mike" });
+    await employee.save();
+
+    const fetchedEmployee = await Employee.findById(employee.id!, {
+      populate: ["generalData"],
+    });
+
+    expect(fetchedEmployee).toBeInstanceOf(Employee);
+    expect(fetchedEmployee?.generalData).toBeNull();
+  });
+
+  it("should handle population on an already-fetched instance", async () => {
+    const employee = new Employee({ name: "Sarah" });
+    await employee.save();
+
+    const general = new GeneralData({ location: "Tokyo" }, employee);
+    general.id = "general";
+    await general.save();
+
+    const fetchedEmployee = await Employee.findById(employee.id!);
+    expect(fetchedEmployee?.generalData).toBeUndefined();
+
+    await fetchedEmployee?.populate("generalData");
+
+    expect(fetchedEmployee?.generalData).toBeInstanceOf(GeneralData);
+    expect(fetchedEmployee?.generalData?.location).toBe("Tokyo");
+  });
+
+  it("should allow managing a subcollection within a SubCollectionDoc", async () => {
+    const employee = new Employee({ name: "Admin User" });
+    await employee.save();
+
+    const masterData = new MasterData({ accessLevel: "super-admin" }, employee);
+    masterData.id = "master-data";
+    await masterData.save();
+
+    const log1 = new AccessLog({ ip: "192.168.1.1" }, masterData);
+    const log2 = new AccessLog({ ip: "127.0.0.1" }, masterData);
+    await log1.save();
+    await log2.save();
+
+    const fetchedEmployee = await Employee.findById(employee.id!, {
+      populate: ["masterData"],
+    });
+
+    const fetchedLogs =
+      await fetchedEmployee?.masterData?.subcollection("accessLogs");
+
+    expect(fetchedEmployee?.masterData).toBeInstanceOf(MasterData);
+    expect(fetchedEmployee?.masterData?.accessLevel).toBe("super-admin");
+
+    expect(fetchedLogs).toBeDefined();
+    expect(fetchedLogs?.length).toBe(2);
+    expect(fetchedLogs?.[0]).toBeInstanceOf(AccessLog);
+
+    const ips = fetchedLogs?.map((log: any) => log.ip).sort();
+    expect(ips).toEqual(["127.0.0.1", "192.168.1.1"]);
+  });
+});


### PR DESCRIPTION
Closes #10

***
### Summary
This pull request introduces a new feature, the @SubCollectionDoc decorator, to provide a declarative and ergonomic way to handle specific documents within a subcollection. It also fixes a critical bug that prevented the ORM from correctly instantiating existing Firestore documents that contain no fields.

### The main motivations are:

Improve DX: Simplify the modeling of one-to-one relationships where the related document lives in a subcollection with a known ID (e.g., /employees/{id}/advanced-data/general).
Fix Bug: Ensure the ORM is robust and behaves correctly, like Firestore itself, by supporting "placeholder" documents that only serve to anchor subcollections.

### Changes Implemented

#### ✨ New `@SubCollectionDoc` Decorator:

A new decorator, @SubCollectionDoc, has been created in src/core/decorators.ts.
It allows a class property to be directly mapped to a document with a fixed ID inside a named subcollection.
The corresponding SubCollectionDocMetadata type was added to src/core/types.ts.

#### 🚀 Enhanced `populate()` Method:

The `BaseModel.populate()` method in `src/core/base-model.ts` has been extended to recognize and process the new `@SubCollectionDoc` metadata, allowing these properties to be populated seamlessly alongside standard `@Relation` fields.

#### 🐞 Bug Fix in `_fromFirestore`:

The `BaseModel._fromFirestore()` method has been patched. It now handles cases where `snapshot.data()` returns undefined for an existing document by defaulting to an empty object ({}).
This prevents a runtime TypeError and ensures that empty documents are correctly instantiated as BaseModel instances, allowing subsequent operations like `.subcollection()` to work as expected.

#### ✅ New Tests:

A new test suite, `tests/subcollection-doc.test.ts`, has been added to provide comprehensive coverage for the new feature.
Tests include scenarios for populating single and multiple documents, handling non-existent documents, and ensuring that nested subcollections within a SubCollectionDoc work correctly.
All model constructors in the test file were updated to maintain a signature compatible with BaseModel, resolving type errors found during development.
How to Verify
Review the implementation of the `@SubCollectionDoc` decorator and the logic updates in BaseModel.

Examine the new test file `tests/subcollection-doc.test.ts` to see the feature in action and understand the expected behavior.

Run the entire test suite to confirm that all existing and new tests pass:

```bash
npm test
```

![image](https://github.com/user-attachments/assets/11f0c57e-261a-43e7-85fd-76b2c36dc021)
